### PR TITLE
Applied direction property to chapter number, title, subtitle

### DIFF
--- a/cssGenerators/getChapterHeaderCss.ts
+++ b/cssGenerators/getChapterHeaderCss.ts
@@ -6,7 +6,8 @@ import {
   getNormalizedOpacity,
   getTitleFontSize,
   getSubTitleFontSize,
-  getChapNumberFontSize
+  getChapNumberFontSize,
+  getTitleDirection
 } from "../helpers";
 
 import { Theme } from "../types";
@@ -114,6 +115,7 @@ export const getChapterHeaderCss = (
       text-align: ${styleProps.chapterNo.align};
       line-height: 1.${styleProps.chapterNo.size};
       width: ${styleProps.chapterNo.width}%;
+      direction: ${getTitleDirection(styleProps.chapterNo.align)};
       ${fontStylesToCssProp(styleProps.chapterNo.style)};
       ${styleObjectToCss(styleProps.chapterNo.extras)};
     }
@@ -125,6 +127,7 @@ export const getChapterHeaderCss = (
       text-align: ${styleProps.chapterTitle.align}!important;
       line-height: 1.${styleProps.chapterTitle.size};
       width: ${styleProps.chapterTitle.width}%;
+      direction: ${getTitleDirection(styleProps.chapterTitle.align)};
       ${fontStylesToCssProp(styleProps.chapterTitle.style)};
       ${styleObjectToCss(styleProps.chapterTitle.extras)};
     }
@@ -136,6 +139,7 @@ export const getChapterHeaderCss = (
       text-align: ${styleProps.chapterSubtitle.align};
       line-height: 1.${styleProps.chapterSubtitle.size};
       width: ${styleProps.chapterSubtitle.width}%;
+      direction: ${getTitleDirection(styleProps.chapterSubtitle.align)};
       ${fontStylesToCssProp(styleProps.chapterSubtitle.style)};
       ${styleObjectToCss(styleProps.chapterSubtitle.extras)};
     }

--- a/helpers/getTitleDirection.ts
+++ b/helpers/getTitleDirection.ts
@@ -1,0 +1,9 @@
+import { Alignment } from "../types/themeProps"
+
+const titleDirectionOrder = new Map([
+    ["right", "rtl"],
+    ["left", "ltr"],
+    ["center", "inherit"],
+]);
+
+export const getTitleDirection = (align: Alignment) => titleDirectionOrder.get(align) || "inherit";

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -5,3 +5,4 @@ export * from "./fontList";
 export * from "./misc";
 export * from "./styleObjectToCssString";
 export * from "./headerElementFontSize";
+export * from "./getTitleDirection";


### PR DESCRIPTION
direction property applies the direction of an HTML element when it overflows. This prevents the chapter number, title, subtitle overflowing out of the page when width is set to low and aligned to right. 