### PR TITLE
Revert "Applied direction property to chapter number, title, subtitle"

### DIFF
--- a/cssGenerators/getChapterHeaderCss.ts
+++ b/cssGenerators/getChapterHeaderCss.ts
@@ -7,7 +7,6 @@ import {
   getTitleFontSize,
   getSubTitleFontSize,
   getChapNumberFontSize,
-  getTitleDirection,
   getFontFamilyName,
   headerStyleToFontVariant,
   addPrefix,
@@ -128,7 +127,6 @@ export const getChapterHeaderCss = (
       text-align: ${styleProps.chapterNo.align};
       line-height: 1.${styleProps.chapterNo.size};
       width: ${styleProps.chapterNo.width}%;
-      direction: ${getTitleDirection(styleProps.chapterNo.align)};
       ${fontStylesToCssProp(styleProps.chapterNo.style)}
       ${styleObjectToCss(styleProps.chapterNo.extras)}
       ${isThumbnail? thumbnailCssOverwrites.number(): ""}
@@ -144,7 +142,6 @@ export const getChapterHeaderCss = (
       text-align: ${styleProps.chapterTitle.align}!important;
       line-height: 1.${styleProps.chapterTitle.size};
       width: ${styleProps.chapterTitle.width}%;
-      direction: ${getTitleDirection(styleProps.chapterTitle.align)};
       ${fontStylesToCssProp(styleProps.chapterTitle.style)}
       ${styleObjectToCss(styleProps.chapterTitle.extras)}
       ${isThumbnail? thumbnailCssOverwrites.title(): ""}
@@ -160,7 +157,6 @@ export const getChapterHeaderCss = (
       text-align: ${styleProps.chapterSubtitle.align};
       line-height: 1.${styleProps.chapterSubtitle.size};
       width: ${styleProps.chapterSubtitle.width}%;
-      direction: ${getTitleDirection(styleProps.chapterSubtitle.align)};
       ${fontStylesToCssProp(styleProps.chapterSubtitle.style)}
       ${styleObjectToCss(styleProps.chapterSubtitle.extras)}
       ${isThumbnail? thumbnailCssOverwrites.subtitle(): ""}

--- a/helpers/getTitleDirection.ts
+++ b/helpers/getTitleDirection.ts
@@ -1,9 +1,0 @@
-import { Alignment } from "../types/themeProps"
-
-const titleDirectionOrder = new Map([
-    ["right", "rtl"],
-    ["left", "ltr"],
-    ["center", "inherit"],
-]);
-
-export const getTitleDirection = (align: Alignment) => titleDirectionOrder.get(align) || "inherit";

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -3,5 +3,5 @@ export * from "./getNormalizedOpacity";
 export * from "./misc";
 export * from "./styleObjectToCssString";
 export * from "./headerElementFontSize";
-export * from "./getTitleDirection";
+
 export * from "./fonts";


### PR DESCRIPTION
This reverts commit 70aa1a029d5ace9181feb458c4f6881ca1cf5878.

Removed the direction property since it's causing validation errors with epub.