### PR TITLE
AT-1065): Display None Limitation on Kindle Previewer

### DIFF
--- a/cssGenerators/chapterTypes/copyright.ts
+++ b/cssGenerators/chapterTypes/copyright.ts
@@ -9,10 +9,6 @@ export const getCopyrightCss = (themeId: string) => {
       margin-bottom: 0.8em;
     }
 
-    .${themeId} .copyrights .chapter-title-card{
-      display: none;
-    }
-
     .${themeId} .copyrights p:first-of-type .word:nth-child(-n+4){
       text-transform: none;
     }
@@ -25,7 +21,7 @@ export const getCopyrightCss = (themeId: string) => {
       margin-right: 0 !important;
     }
 
-    .${themeId} .copyrights .chapter-title-card{
+    .copyrights .chapter-title-card{
       display: none !important;
     }
   `;

--- a/cssGenerators/chapterTypes/dedication.ts
+++ b/cssGenerators/chapterTypes/dedication.ts
@@ -1,6 +1,6 @@
 export const getDedicationCss = (themeId: string) => {
   return `
-    .${themeId} .dedication .chapter-title-card{
+    .dedication .chapter-title-card{
       display: none !important;
     }
 

--- a/cssGenerators/chapterTypes/epigraph.ts
+++ b/cssGenerators/chapterTypes/epigraph.ts
@@ -1,6 +1,6 @@
 export const getEpigraphCss = (themeId: string) => {
   return `
-    .${themeId} .epigraph .chapter-title-card{
+    .epigraph .chapter-title-card{
       display: none !important;
     }
 


### PR DESCRIPTION
 `themeId` is used as a class for the wrapper div in all the pages. Kindle previewer weirdly considers these `display: none` styles are getting applied to everything in their css validation w/o considering the other class selectors. That was causing the error `E3013: More number of characters are hidden using display:none than allowed limit. Limit: 10000` on Kindle Previewer. 

As a fix for that removed the `themeId` from the places where `display: none` was used. 