### PR TITLE
AT-1098 The image opacity selected in the theme isn’t showing in the preview

### DIFF
--- a/cssGenerators/getChapterHeaderCss.ts
+++ b/cssGenerators/getChapterHeaderCss.ts
@@ -30,7 +30,7 @@ export const getChapterHeaderCss = (
     styleProps.image?.headerTextColor === "light";
 
   return `
-    .${themeProps._id} .${addPrefix("chp_bg")}{
+    .${themeProps._id} .${addPrefix("chp_bg", prefix)}{
       background-color: rgba(255,255,255, ${1 - getNormalizedOpacity(
         styleProps.image.opacity
       )});


### PR DESCRIPTION
bugfix/AT-1098 Add missing class prefix to css class responsible for changing image opacity