### PR TITLE
bugfix/AT-1535 [Atticus ] [Hanging Indent] gap between two hanging indents higher than the normal text

### DIFF
--- a/cssGenerators/editorPlugins/hangingIndent.ts
+++ b/cssGenerators/editorPlugins/hangingIndent.ts
@@ -2,8 +2,6 @@ export const getHangingIndentCss = (prefixRule: string) => {
     return `
       ${prefixRule}.hanging{
         line-height: 1.6em;
-        padding-top: 0.75rem;
-        padding-bottom: 0.75rem;
         text-indent: -0.25in;
         padding-left: 0.25in;
         orphans: 3; 


### PR DESCRIPTION
- AT-1531 Alignment Block with Hanging Indents
- AT-1535 Implementation
- AT-1826 [Atticus ] [Hanging Indent] gap between two hanging indent higher than the normal text 